### PR TITLE
PROX-458: tax required -> tax optional

### DIFF
--- a/proto/cashreg_receipt.thrift
+++ b/proto/cashreg_receipt.thrift
@@ -42,5 +42,5 @@ struct ItemsLine {
     1: required string      product
     2: required i32         quantity
     3: required domain.Cash price
-    4: required string      tax
+    4: optional string      tax
 }


### PR DESCRIPTION
Т.к. у нас [tax](https://github.com/rbkmoney/damsel/blob/master/proto/domain.thrift#L154) не обязателен в протоколе damsel, а точнее там всегда приходит параметр, который может быть null
```
"taxMode": {
"type": "InvoiceLineTaxVAT"
}
```
и отсутствие параметра в виде значения null говорит о том, что ставка `Без ндс`, то в нашем протоколе тоже нужно сделать его опциональным и преобразовывать на основании этого в адаптерах. Хотя, в идеале, хорошо бы создать параметр `Без ндс` на уровне [swag-а](https://developer.rbk.money/api/#operation/createInvoice), чтобы в будущем избегать подобных нюансов.